### PR TITLE
Fix HUGO_ENV not getting set during CI builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [6.3.2] - 2022-02-10
+
+* Fix setting the `HUGO_ENV` to `production` for production builds.
+* This fixes google analytics script not getting injected
+
 ## [6.3.1] - 2021-10-18
 
 * Only inject google analytics script in prod

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,5 +3,5 @@ set -e
 
 source ./scripts/include/vars.sh
 
-set HUGO_ENV=production
+export HUGO_ENV=production
 hugo --minify --buildFuture --cleanDestinationDir --destination $DIST_DIR


### PR DESCRIPTION
### What are you changing?

Using `export` instead of `set` in the build.sh script to correctly set the `HUGO_ENV` to `production`.

### Why are you making this change?

Google analytics script was not getting injected during the CI process because of missing `HUGO_ENV`


